### PR TITLE
Added Support for DocumentReference field types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,5 @@ typings/
 # next.js build output
 .next
 
-# prettier config files
-.prettierrc.json
-.prettierignore
-
 # build output
 lib/

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,9 @@ typings/
 # next.js build output
 .next
 
+# prettier config files
+.prettierrc.json
+.prettierignore
+
 # build output
 lib/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 # This file is intentionally left blank.
+!lib/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+jest.config.js
+package.json
+tsconfig.json
+lib/
+.opensource/
+.prettierrc.json
+.travis.yml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote":true
+}

--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ const { posts: postsBySomeAuthor } = await firegraph.resolve(
 
 ### Ordering Results
 
-The result of sub/collections can be ordered by using the `orderby` clause, with providing an object containing fields and their order type of either `asc`ending or `desc`ending
+The result of sub/collections can be ordered by using the `orderBy` clause, with providing an object containing fields and their order type of either `asc`ending or `desc`ending
 
 ```typescript
 const { posts } = await firegraph.resolve(
   firestore,
   gql`
     query {
-      posts(orderby: { createdOn: "desc", title: "asc" }) {
+      posts(orderBy: { createdOn: "desc", title: "asc" }) {
         id
         title
         createdOn

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ document in the response. Note: `id` is a special field that actually retrieves
 the document key.
 
 ```typescript
-const { posts } = await firegraph.resolve(firestore, gql`
+const { posts } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
       posts {
         id
@@ -63,7 +65,8 @@ const { posts } = await firegraph.resolve(firestore, gql`
         body
       }
     }
-  `);
+  `
+);
 ```
 
 ### Subcollections
@@ -74,7 +77,9 @@ we also retrieve the `posts/${doc.id}/comments` collection. This result is
 stored in the `comments` key for each document that is returned.
 
 ```typescript
-const { posts: postsWithComments } = await firegraph.resolve(firestore, gql`
+const { posts: postsWithComments } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
       posts {
         id
@@ -86,7 +91,8 @@ const { posts: postsWithComments } = await firegraph.resolve(firestore, gql`
         }
       }
     }
-  `);
+  `
+);
 ```
 
 ### Document References
@@ -96,7 +102,9 @@ If `post.author` is a `DocumentReference` field, it is considered as a complete 
 If `post.author` is a `String` type of field, it is also considered as a complete path to document. However, you can optionally provide a parent path to the document collection using the `path` argument. Note that path argument must end in a `"/"` to be valid.
 
 ```typescript
-const { posts: postsWithAuthorAndComments } = await firegraph.resolve(firestore, gql`
+const { posts: postsWithAuthorAndComments } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
       posts {
         id
@@ -123,7 +131,8 @@ const { posts: postsWithAuthorAndComments } = await firegraph.resolve(firestore,
         }
       }
     }
-  `);
+  `
+);
 ```
 
 ### Filtering Results
@@ -144,7 +153,9 @@ are some of the first things we are hoping to add support for.
 
 ```typescript
 const authorId = 'sZOgUC33ijsGSzX17ybT';
-const { posts: postsBySomeAuthor } = await firegraph.resolve(firestore, gql`
+const { posts: postsBySomeAuthor } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
         posts(where: {
             author: ${authorId},
@@ -157,7 +168,8 @@ const { posts: postsBySomeAuthor } = await firegraph.resolve(firestore, gql`
             }
         }
     }
-`);
+`
+);
 ```
 
 ### Ordering Results
@@ -165,7 +177,9 @@ const { posts: postsBySomeAuthor } = await firegraph.resolve(firestore, gql`
 The result of sub/collections can be ordered by using the `orderby` clause, with providing an object containing fields and their order type of either `asc`ending or `desc`ending
 
 ```typescript
-const { posts } = await firegraph.resolve(firestore, gql`
+const { posts } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
       posts(orderby: { createdOn: "desc", title: "asc" }) {
         id
@@ -174,7 +188,8 @@ const { posts } = await firegraph.resolve(firestore, gql`
         body
       }
     }
-  `);
+  `
+);
 ```
 
 **NOTE:** The `indexes` for ordering fields _must be created beforehand_ in firebase console, and those fields _should be part of the query_.
@@ -184,7 +199,9 @@ const { posts } = await firegraph.resolve(firestore, gql`
 To limit the loading of documents to a certain number in a sub/collection query, `limit` argument can be supplied to the query.
 
 ```typescript
-const { posts } = await firegraph.resolve(firestore, gql`
+const { posts } = await firegraph.resolve(
+  firestore,
+  gql`
     query {
       posts(limit: 10) {
         id
@@ -196,7 +213,8 @@ const { posts } = await firegraph.resolve(firestore, gql`
         }
       }
     }
-  `);
+  `
+);
 ```
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 > This is **not** an official Google product, nor is it maintained or supported by Google employees. For support with Firebase or Firestore, please [click here](https://firebase.google.com/support/).
 
-___
+---
 
 # Introduction
 
@@ -30,11 +30,11 @@ Firestore makes it easy to securely store and retrieve data, and already has a p
 
 # Getting Started
 
-Getting started with Firegraph is very easy! **You do not need to host a GraphQL server to use Firegraph.** However, your project does require some GraphQL-related dependencies. 
+Getting started with Firegraph is very easy! **You do not need to host a GraphQL server to use Firegraph.** However, your project does require some GraphQL-related dependencies.
 
 ## Installing
 
-``` bash
+```bash
 # npm
 npm install --save graphql graphql-tag firegraph
 
@@ -54,16 +54,16 @@ collection and retrieving the `id`, `title`, and `body` values from each
 document in the response. Note: `id` is a special field that actually retrieves
 the document key.
 
-``` typescript
+```typescript
 const { posts } = await firegraph.resolve(firestore, gql`
     query {
-        posts {
-            id
-            title
-            body
-        }
+      posts {
+        id
+        title
+        body
+      }
     }
-`)
+  `);
 ```
 
 ### Subcollections
@@ -73,20 +73,20 @@ as child collections. To clarify, for each `doc` in the `posts` collection,
 we also retrieve the `posts/${doc.id}/comments` collection. This result is
 stored in the `comments` key for each document that is returned.
 
-``` typescript
+```typescript
 const { posts: postsWithComments } = await firegraph.resolve(firestore, gql`
     query {
-        posts {
-            id
-            title
-            body
-            comments {
-                id
-                body
-            }
+      posts {
+        id
+        title
+        body
+        comments {
+          id
+          body
         }
+      }
     }
-`)
+  `);
 ```
 
 ### Document References
@@ -95,35 +95,35 @@ If `post.author` is a `DocumentReference` field, it is considered as a complete 
 
 If `post.author` is a `String` type of field, it is also considered as a complete path to document. However, you can optionally provide a parent path to the document collection using the `path` argument. Note that path argument must end in a `"/"` to be valid.
 
-``` typescript
+```typescript
 const { posts: postsWithAuthorAndComments } = await firegraph.resolve(firestore, gql`
     query {
-        posts {
-            id
-            title
-            body
+      posts {
+        id
+        title
+        body
 
-            # Here author is either a DocumentReference type of field
-            # or is a String field with complete path to the document
-            author {
-                id
-                displayName
-            }
-
-            comments {
-                id
-                body
-
-                # Here author's id is only saved in the field,
-                # hence parent path to document is provided
-                authorId(path: "users/") {
-                    id
-                    displayName
-                }
-            }
+        # Here author is either a DocumentReference type of field
+        # or is a String field with complete path to the document
+        author {
+          id
+          displayName
         }
+
+        comments {
+          id
+          body
+
+          # Here author's id is only saved in the field,
+          # hence parent path to document is provided
+          authorId(path: "users/") {
+            id
+            displayName
+          }
+        }
+      }
     }
-`)
+  `);
 ```
 
 ### Filtering Results
@@ -142,7 +142,7 @@ For the last one, of course, `someKey` would have to use Firestore's array type.
 related to compound queries with Firestore (no logical OR or inequality testing) still apply but those
 are some of the first things we are hoping to add support for.
 
-``` typescript
+```typescript
 const authorId = 'sZOgUC33ijsGSzX17ybT';
 const { posts: postsBySomeAuthor } = await firegraph.resolve(firestore, gql`
     query {
@@ -151,14 +151,53 @@ const { posts: postsBySomeAuthor } = await firegraph.resolve(firestore, gql`
         }) {
             id
             message
-            author(matchesKeyFromCollection: "users") {
+            author {
                 id
+                displayName
             }
         }
     }
 `);
 ```
 
+### Ordering Results
+
+The result of sub/collections can be ordered by using the `orderby` clause, with providing an object containing fields and their order type of either `asc`ending or `desc`ending
+
+```typescript
+const { posts } = await firegraph.resolve(firestore, gql`
+    query {
+      posts(orderby: { createdOn: "desc", title: "asc" }) {
+        id
+        title
+        createdOn
+        body
+      }
+    }
+  `);
+```
+
+**NOTE:** The `indexes` for ordering fields _must be created beforehand_ in firebase console, and those fields _should be part of the query_.
+
+### Limiting Results
+
+To limit the loading of documents to a certain number in a sub/collection query, `limit` argument can be supplied to the query.
+
+```typescript
+const { posts } = await firegraph.resolve(firestore, gql`
+    query {
+      posts(limit: 10) {
+        id
+        title
+        body
+        comments(limit: 10) {
+          id
+          message
+        }
+      }
+    }
+  `);
+```
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ const { posts: postsWithComments } = await firegraph.resolve(firestore, gql`
 
 ### Document References
 
-Right now, we are assuming that `post.author` is a string that matches the ID of some document in the `users` collection. In the future we will leverage Firestore's `DocumentReference` value type to handle both use cases.
+If `post.author` is a `DocumentReference` field, it is considered as a complete path to the document from the root of the database.
+
+If `post.author` is a `String` type of field, it is also considered as a complete path to document. However, you can optionally provide a parent path to the document collection using the `path` argument. Note that path argument must end in a `"/"` to be valid.
 
 ``` typescript
 const { posts: postsWithAuthorAndComments } = await firegraph.resolve(firestore, gql`
@@ -100,14 +102,21 @@ const { posts: postsWithAuthorAndComments } = await firegraph.resolve(firestore,
             id
             title
             body
-            author(matchesKeyFromCollection: "users") {
+
+            # Here author is either a DocumentReference type of field
+            # or is a String field with complete path to the document
+            author {
                 id
                 displayName
             }
+
             comments {
                 id
                 body
-                author(matchesKeyFromCollection: "users") {
+
+                # Here author's id is only saved in the field,
+                # hence parent path to document is provided
+                authorId(path: "users/") {
                     id
                     displayName
                 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "firebase-mock": "^2.3.2",
     "jest": "^27.0.6",
     "npm-auto-version": "^1.0.0",
+    "prettier": "^2.3.2",
     "ts-jest": "^27.0.3",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.10"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --env=node",
     "start": "ts-node src/index.ts",
-    "install": "tsc -p tsconfig.json --outDir lib",
+    "build": "tsc -p tsconfig.json --outDir lib",
     "examples:types": "ts-node example/types.ts",
     "examples:references": "ts-node example/references.ts",
     "prepublish": "yarn build && npm-auto-version",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.11",
   "license": "MIT",
   "scripts": {
-    "test": "jest --env=jsdom --browser",
+    "test": "jest --env=node",
     "start": "ts-node src/index.ts",
     "install": "tsc -p tsconfig.json --outDir lib",
     "examples:types": "ts-node example/types.ts",
@@ -23,9 +23,9 @@
     "@types/jest": "^23.3.14",
     "dotenv": "^6.2.0",
     "firebase-mock": "^2.3.2",
-    "jest": "^24.9.0",
+    "jest": "^27.0.6",
     "npm-auto-version": "^1.0.0",
-    "ts-jest": "^23.10.5",
+    "ts-jest": "^27.0.3",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.10"
   }

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
     "postpublish": "git push origin --tags"
   },
   "dependencies": {
-    "firebase": "^5.8.1",
-    "graphql": "^14.1.1",
-    "graphql-tag": "^2.10.1"
+    "firebase": "^8.7.1",
+    "graphql": "^15.5.1",
+    "graphql-tag": "^2.12.5"
   },
   "devDependencies": {
-    "@types/dotenv": "^6.1.0",
-    "@types/jest": "^23.3.13",
+    "@types/dotenv": "^6.1.1",
+    "@types/jest": "^23.3.14",
     "dotenv": "^6.2.0",
-    "firebase-mock": "^2.2.10",
-    "jest": "^24.0.0",
+    "firebase-mock": "^2.3.2",
+    "jest": "^24.9.0",
     "npm-auto-version": "^1.0.0",
     "ts-jest": "^23.10.5",
-    "ts-node": "^8.0.2",
-    "typescript": "^3.3.1"
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --env=jsdom --browser",
     "start": "ts-node src/index.ts",
-    "build": "tsc -p tsconfig.json --outDir lib",
+    "install": "tsc -p tsconfig.json --outDir lib",
     "examples:types": "ts-node example/types.ts",
     "examples:references": "ts-node example/references.ts",
     "prepublish": "yarn build && npm-auto-version",

--- a/src/firegraph/CacheManager.ts
+++ b/src/firegraph/CacheManager.ts
@@ -1,46 +1,50 @@
-interface CacheManagerListener{
-  onCacheHit:(path:string)=>void;
-  onCacheMiss:(path:string)=>void;
-  onCacheRequested:(path:string)=>void;
-  onCacheSaved:(path:string)=>void;
+export interface CacheManagerListener {
+  onCacheHit: (path: string) => void;
+  onCacheMiss: (path: string) => void;
+  onCacheRequested: (path: string) => void;
+  onCacheSaved: (path: string) => void;
 }
 
-class CacheManager{
+export class CacheManager {
   private cache = Object.create(null);
-  private static listeners:CacheManagerListener[] = [];
+  private static listeners: CacheManagerListener[] = [];
 
-  public getDocument(path: string):firebase.default.firestore.DocumentSnapshot|undefined{
-    const doc:firebase.default.firestore.DocumentSnapshot = this.cache[path];
+  public getDocument(
+    path: string
+  ): firebase.default.firestore.DocumentSnapshot | undefined {
+    const doc: firebase.default.firestore.DocumentSnapshot = this.cache[path];
 
     // Call listeners
-    CacheManager.listeners.forEach((listener)=>listener.onCacheRequested(path));
-    if(doc == undefined){
-      CacheManager.listeners.forEach((listener)=>listener.onCacheMiss(path));
-    }else{
-      CacheManager.listeners.forEach((listener)=>listener.onCacheHit(path));
+    CacheManager.listeners.forEach((listener) =>
+      listener.onCacheRequested(path)
+    );
+    if (doc == undefined) {
+      CacheManager.listeners.forEach((listener) => listener.onCacheMiss(path));
+    } else {
+      CacheManager.listeners.forEach((listener) => listener.onCacheHit(path));
     }
 
     return doc;
   }
 
-  public saveDocument(path:string, document: firebase.default.firestore.DocumentSnapshot){
+  public saveDocument(
+    path: string,
+    document: firebase.default.firestore.DocumentSnapshot
+  ) {
     this.cache[path] = document;
-    CacheManager.listeners.forEach((listener)=>listener.onCacheSaved(path));
+    CacheManager.listeners.forEach((listener) => listener.onCacheSaved(path));
   }
 
-  public static addListener(listener: CacheManagerListener){
+  public static addListener(listener: CacheManagerListener) {
     CacheManager.listeners.push(listener);
   }
 
-  public static removeListener(listener: CacheManagerListener){
+  public static removeListener(listener: CacheManagerListener) {
     const index = CacheManager.listeners.indexOf(listener);
     CacheManager.listeners.splice(index, 1);
   }
-  
-  public static removeAllListeners(){
+
+  public static removeAllListeners() {
     CacheManager.listeners = [];
   }
-
 }
-
-export default CacheManager;

--- a/src/firegraph/CacheManager.ts
+++ b/src/firegraph/CacheManager.ts
@@ -1,0 +1,46 @@
+interface CacheManagerListener{
+  onCacheHit:(path:string)=>void;
+  onCacheMiss:(path:string)=>void;
+  onCacheRequested:(path:string)=>void;
+  onCacheSaved:(path:string)=>void;
+}
+
+class CacheManager{
+  private cache = Object.create(null);
+  private static listeners:CacheManagerListener[] = [];
+
+  public getDocument(path: string):firebase.default.firestore.DocumentSnapshot|undefined{
+    const doc:firebase.default.firestore.DocumentSnapshot = this.cache[path];
+
+    // Call listeners
+    CacheManager.listeners.forEach((listener)=>listener.onCacheRequested(path));
+    if(doc == undefined){
+      CacheManager.listeners.forEach((listener)=>listener.onCacheMiss(path));
+    }else{
+      CacheManager.listeners.forEach((listener)=>listener.onCacheHit(path));
+    }
+
+    return doc;
+  }
+
+  public saveDocument(path:string, document: firebase.default.firestore.DocumentSnapshot){
+    this.cache[path] = document;
+    CacheManager.listeners.forEach((listener)=>listener.onCacheSaved(path));
+  }
+
+  public static addListener(listener: CacheManagerListener){
+    CacheManager.listeners.push(listener);
+  }
+
+  public static removeListener(listener: CacheManagerListener){
+    const index = CacheManager.listeners.indexOf(listener);
+    CacheManager.listeners.splice(index, 1);
+  }
+  
+  public static removeAllListeners(){
+    CacheManager.listeners = [];
+  }
+
+}
+
+export default CacheManager;

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -2,6 +2,7 @@ import { GraphQLSelectionSet } from '../types/GraphQL';
 import { FiregraphCollectionResult } from '../types/Firegraph';
 import { resolveDocument } from './Document';
 import { setQueryFilters } from './Where';
+import { setOrders } from './Order';
 
 /**
  * Retrieves documents from a specified collection path. Currently retrieves
@@ -32,6 +33,11 @@ export async function resolveCollection(
         if(collectionArgs['limit']){
             const limit = collectionArgs['limit'];
             collectionQuery = collectionQuery.limit(limit);
+        }
+
+        if(collectionArgs['order']){
+          const orders = collectionArgs['order'];
+          collectionQuery = setOrders(collectionQuery, orders);
         }
     }
 

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -35,8 +35,8 @@ export async function resolveCollection(
             collectionQuery = collectionQuery.limit(limit);
         }
 
-        if(collectionArgs['order']){
-          const orders = collectionArgs['order'];
+        if(collectionArgs['orderby']){
+          const orders = collectionArgs['orderby'];
           collectionQuery = setOrders(collectionQuery, orders);
         }
     }

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -12,7 +12,7 @@ import { setQueryFilters } from './Where';
  * @param selectionSet The rules for defining the documents we want to get.
  */
 export async function resolveCollection(
-    store: firebase.firestore.Firestore,
+    store: firebase.default.firestore.Firestore,
     collectionName: string,
     collectionArgs: { [key:string]: any },
     selectionSet: GraphQLSelectionSet

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -28,6 +28,11 @@ export async function resolveCollection(
             const where = collectionArgs['where'];
             collectionQuery = setQueryFilters(collectionQuery, where);
         }
+
+        if(collectionArgs['limit']){
+            const limit = collectionArgs['limit'];
+            collectionQuery = collectionQuery.limit(limit);
+        }
     }
 
     const collectionSnapshot = await collectionQuery.get();

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -34,7 +34,7 @@ export async function resolveCollection(
         }
 
         if(collectionArgs['limit']){
-            const limit = collectionArgs['limit'];
+            const limit:number = Number.parseInt(collectionArgs['limit']);
             collectionQuery = collectionQuery.limit(limit);
         }
 

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -39,8 +39,8 @@ export async function resolveCollection(
       collectionQuery = collectionQuery.limit(limit);
     }
 
-    if (collectionArgs['orderby']) {
-      const orders = collectionArgs['orderby'];
+    if (collectionArgs['orderBy']) {
+      const orders = collectionArgs['orderBy'];
       collectionQuery = setOrders(collectionQuery, orders);
     }
   }

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -1,9 +1,10 @@
+import firebase from 'firebase/app';
 import { GraphQLSelectionSet } from '../types/GraphQL';
 import { FiregraphCollectionResult } from '../types/Firegraph';
 import { resolveDocument } from './Document';
 import { setQueryFilters } from './Where';
 import { setOrders } from './Order';
-import CacheManager from './CacheManager';
+import { CacheManager } from './CacheManager';
 
 /**
  * Retrieves documents from a specified collection path. Currently retrieves
@@ -12,49 +13,46 @@ import CacheManager from './CacheManager';
  * @param store An initialized Firestore instance.
  * @param collectionName The path of the collection we want to retrieve.
  * @param selectionSet The rules for defining the documents we want to get.
- * @param cacheManager An instance of cache manager to pass on to the doucments fetcher
+ * @param cacheManager An instance of cache manager to pass on to the documents fetcher
  */
 export async function resolveCollection(
-    store: firebase.default.firestore.Firestore,
-    collectionName: string,
-    collectionArgs: { [key:string]: any },
-    selectionSet: GraphQLSelectionSet,
-    cacheManager: CacheManager
+  store: firebase.firestore.Firestore,
+  collectionName: string,
+  collectionArgs: { [key: string]: any },
+  selectionSet: GraphQLSelectionSet,
+  cacheManager: CacheManager
 ): Promise<FiregraphCollectionResult> {
-    let collectionQuery: any = store.collection(collectionName);
-    let collectionResult: FiregraphCollectionResult = {
-        name: collectionName,
-        docs: []
-    };
+  let collectionQuery: any = store.collection(collectionName);
+  let collectionResult: FiregraphCollectionResult = {
+    name: collectionName,
+    docs: [],
+  };
 
-    if (collectionArgs) {
-        if (collectionArgs['where']) {
-            const where = collectionArgs['where'];
-            collectionQuery = setQueryFilters(collectionQuery, where);
-        }
-
-        if(collectionArgs['limit']){
-            const limit:number = Number.parseInt(collectionArgs['limit']);
-            collectionQuery = collectionQuery.limit(limit);
-        }
-
-        if(collectionArgs['orderby']){
-          const orders = collectionArgs['orderby'];
-          collectionQuery = setOrders(collectionQuery, orders);
-        }
+  if (collectionArgs) {
+    if (collectionArgs['where']) {
+      const where = collectionArgs['where'];
+      collectionQuery = setQueryFilters(collectionQuery, where);
     }
 
-    const collectionSnapshot = await collectionQuery.get();
-    if (selectionSet && selectionSet.selections) {
-        for (let doc of collectionSnapshot.docs) {
-            const documentPath = `${collectionName}/${doc.id}`;
-            collectionResult.docs.push(await resolveDocument(
-                store,
-                documentPath,
-                selectionSet,
-                cacheManager
-            ));
-        }
+    if (collectionArgs['limit']) {
+      const limit: number = Number.parseInt(collectionArgs['limit']);
+      collectionQuery = collectionQuery.limit(limit);
     }
-    return collectionResult;
+
+    if (collectionArgs['orderby']) {
+      const orders = collectionArgs['orderby'];
+      collectionQuery = setOrders(collectionQuery, orders);
+    }
+  }
+
+  const collectionSnapshot = await collectionQuery.get();
+  if (selectionSet && selectionSet.selections) {
+    for (let doc of collectionSnapshot.docs) {
+      const documentPath = `${collectionName}/${doc.id}`;
+      collectionResult.docs.push(
+        await resolveDocument(store, documentPath, selectionSet, cacheManager)
+      );
+    }
+  }
+  return collectionResult;
 }

--- a/src/firegraph/Collection.ts
+++ b/src/firegraph/Collection.ts
@@ -3,6 +3,7 @@ import { FiregraphCollectionResult } from '../types/Firegraph';
 import { resolveDocument } from './Document';
 import { setQueryFilters } from './Where';
 import { setOrders } from './Order';
+import CacheManager from './CacheManager';
 
 /**
  * Retrieves documents from a specified collection path. Currently retrieves
@@ -11,12 +12,14 @@ import { setOrders } from './Order';
  * @param store An initialized Firestore instance.
  * @param collectionName The path of the collection we want to retrieve.
  * @param selectionSet The rules for defining the documents we want to get.
+ * @param cacheManager An instance of cache manager to pass on to the doucments fetcher
  */
 export async function resolveCollection(
     store: firebase.default.firestore.Firestore,
     collectionName: string,
     collectionArgs: { [key:string]: any },
-    selectionSet: GraphQLSelectionSet
+    selectionSet: GraphQLSelectionSet,
+    cacheManager: CacheManager
 ): Promise<FiregraphCollectionResult> {
     let collectionQuery: any = store.collection(collectionName);
     let collectionResult: FiregraphCollectionResult = {
@@ -49,7 +52,7 @@ export async function resolveCollection(
                 store,
                 documentPath,
                 selectionSet,
-                doc
+                cacheManager
             ));
         }
     }

--- a/src/firegraph/Document.ts
+++ b/src/firegraph/Document.ts
@@ -11,13 +11,13 @@ import { resolveCollection } from './Collection';
  * @param selectionSet The rules for defining the documents we want to get.
  */
 export async function resolveDocument(
-    store: firebase.firestore.Firestore,
+    store: firebase.default.firestore.Firestore,
     documentPath: string,
     selectionSet: GraphQLSelectionSet,
-    fetchedDocument?: firebase.firestore.DocumentSnapshot
+    fetchedDocument?: firebase.default.firestore.DocumentSnapshot
 ): Promise<FiregraphResult> {
     let data: any;
-    let doc: firebase.firestore.DocumentSnapshot;
+    let doc: firebase.default.firestore.DocumentSnapshot;
     let docResult: FiregraphResult = {};
 
     // If this function is passed with a Firestore document (i.e. from the 

--- a/src/firegraph/Document.ts
+++ b/src/firegraph/Document.ts
@@ -1,7 +1,8 @@
+import firebase from 'firebase/app';
 import { GraphQLSelectionSet } from '../types/GraphQL';
 import { FiregraphResult } from '../types/Firegraph';
 import { resolveCollection } from './Collection';
-import CacheManager from './CacheManager';
+import { CacheManager } from './CacheManager';
 
 /**
  * Retrieves a single document from a specified document path. Retrieves
@@ -13,98 +14,101 @@ import CacheManager from './CacheManager';
  * @param cacheManager An instance of cache manager to use
  */
 export async function resolveDocument(
-    store: firebase.default.firestore.Firestore,
-    documentPath: string,
-    selectionSet: GraphQLSelectionSet,
-    cacheManager: CacheManager,
-    fetchedDocument?: firebase.default.firestore.DocumentSnapshot,
+  store: firebase.firestore.Firestore,
+  documentPath: string,
+  selectionSet: GraphQLSelectionSet,
+  cacheManager: CacheManager,
+  fetchedDocument?: firebase.firestore.DocumentSnapshot
 ): Promise<FiregraphResult> {
-    let data: any;
-    let doc: firebase.default.firestore.DocumentSnapshot;
-    let docResult: FiregraphResult = {};
-    let cachedDoc = cacheManager.getDocument(documentPath);
+  let data: any;
+  let doc: firebase.firestore.DocumentSnapshot;
+  let docResult: FiregraphResult = {};
+  let cachedDoc = cacheManager.getDocument(documentPath);
 
-    // If cache is found, use it
-    if(cachedDoc != undefined) {
-        doc = cachedDoc;
-        data = doc.data();
-    }
-    // If this function is passed with a Firestore document (i.e. from the 
-    // `resolveCollection` API), we don't need to fetch it again.
-    else if (fetchedDocument) {
-        doc = fetchedDocument;
-        data = fetchedDocument.data();
-    } else {
-        doc = await store.doc(documentPath).get();
-        data = doc.data();
+  // If cache is found, use it
+  if (cachedDoc != undefined) {
+    doc = cachedDoc;
+    data = doc.data();
+  }
+  // If this function is passed with a Firestore document (i.e. from the
+  // `resolveCollection` API), we don't need to fetch it again.
+  else if (fetchedDocument) {
+    doc = fetchedDocument;
+    data = fetchedDocument.data();
+  } else {
+    doc = await store.doc(documentPath).get();
+    data = doc.data();
 
-        // Add document to cache
-        cacheManager.saveDocument(documentPath, doc);
-    }
+    // Add document to cache
+    cacheManager.saveDocument(documentPath, doc);
+  }
 
-    if (selectionSet && selectionSet.selections) {
-        const fieldsToRetrieve = selectionSet.selections;
-        for (let field of fieldsToRetrieve) {
-            let args: any = {};
-            for (let arg of field.arguments!) {
-                args[(arg as any).name.value] = (arg as any).value.value
-            }
-            const fieldName = (field as any).name.value;
-            const { selectionSet } = field;
+  if (selectionSet && selectionSet.selections) {
+    const fieldsToRetrieve = selectionSet.selections;
+    for (let field of fieldsToRetrieve) {
+      let args: any = {};
+      for (let arg of field.arguments!) {
+        args[(arg as any).name.value] = (arg as any).value.value;
+      }
+      const fieldName = (field as any).name.value;
+      const { selectionSet } = field;
 
-            // Here we handle document references and nested collections.
-            // First, we need to determine which one we are dealing with.
-            if (selectionSet && selectionSet.selections) {
-                let nestedPath: string;
+      // Here we handle document references and nested collections.
+      // First, we need to determine which one we are dealing with.
+      if (selectionSet && selectionSet.selections) {
+        let nestedPath: string;
 
-                // If its just raw path of some document
-                if ((typeof data[fieldName]) == "string") { 
-                    const docId = data[fieldName];
+        // If its just raw path of some document
+        if (typeof data[fieldName] == 'string') {
+          const docId = data[fieldName];
 
-                    // If parent path is provided, consider it
-                    const { path } = args;
-                    let documentParentPath:string = path ? path : "";
+          // If parent path is provided, consider it
+          const { path } = args;
+          let documentParentPath: string = path ? path : '';
 
-                    nestedPath = `${documentParentPath}${docId}`;
-                    const nestedResult = await resolveDocument(
-                      store,
-                      nestedPath,
-                      selectionSet,
-                      cacheManager
-                    );
-                    docResult[fieldName] = nestedResult;
-                
-                // if field is of Document Reference type, use its path to resolve the document
-                } else if (data[fieldName] != undefined && data[fieldName].constructor!.name! == "DocumentReference") {
-                    nestedPath = `${data[fieldName].path}`;
-                    const nestedResult = await resolveDocument(
-                        store,
-                        nestedPath,
-                        selectionSet,
-                        cacheManager
-                    );
-                    docResult[fieldName] = nestedResult;
+          nestedPath = `${documentParentPath}${docId}`;
+          const nestedResult = await resolveDocument(
+            store,
+            nestedPath,
+            selectionSet,
+            cacheManager
+          );
+          docResult[fieldName] = nestedResult;
 
-                // Else consider it a nested collection.
-                } else {
-                    nestedPath = `${documentPath}/${fieldName}`;
-                    const nestedResult = await resolveCollection(
-                        store,
-                        nestedPath,
-                        args,
-                        selectionSet,
-                        cacheManager
-                    );
-                    docResult[fieldName] = nestedResult.docs;
-                }
-            } else {
-                if (fieldName === 'id') {
-                    docResult[fieldName] = doc.id;
-                } else {
-                    docResult[fieldName] = data[fieldName];
-                }
-            }
+          // if field is of Document Reference type, use its path to resolve the document
+        } else if (
+          data[fieldName] != undefined &&
+          data[fieldName].constructor!.name! == 'DocumentReference'
+        ) {
+          nestedPath = `${data[fieldName].path}`;
+          const nestedResult = await resolveDocument(
+            store,
+            nestedPath,
+            selectionSet,
+            cacheManager
+          );
+          docResult[fieldName] = nestedResult;
+
+          // Else consider it a nested collection.
+        } else {
+          nestedPath = `${documentPath}/${fieldName}`;
+          const nestedResult = await resolveCollection(
+            store,
+            nestedPath,
+            args,
+            selectionSet,
+            cacheManager
+          );
+          docResult[fieldName] = nestedResult.docs;
         }
+      } else {
+        if (fieldName === 'id') {
+          docResult[fieldName] = doc.id;
+        } else {
+          docResult[fieldName] = data[fieldName];
+        }
+      }
     }
-    return docResult;
+  }
+  return docResult;
 }

--- a/src/firegraph/Document.ts
+++ b/src/firegraph/Document.ts
@@ -44,12 +44,16 @@ export async function resolveDocument(
             // First, we need to determine which one we are dealing with.
             if (selectionSet && selectionSet.selections) {
                 let nestedPath: string;
-                const { matchesKeyFromCollection } = args;
+                const { path } = args;
 
-                // If its just ID of some document from a collection & collection path is provided
-                if (matchesKeyFromCollection) {
+                // If its just raw path of some document
+                if ((typeof data[fieldName]) == "string") { 
                     const docId = data[fieldName];
-                    nestedPath = `${matchesKeyFromCollection}/${docId}`;
+
+                    // If parent path is provided, consider it
+                    let documentParentPath:string = path ? path : "";
+
+                    nestedPath = `${documentParentPath}${docId}`;
                     const nestedResult = await resolveDocument(
                       store,
                       nestedPath,

--- a/src/firegraph/Document.ts
+++ b/src/firegraph/Document.ts
@@ -46,10 +46,20 @@ export async function resolveDocument(
                 let nestedPath: string;
                 const { matchesKeyFromCollection } = args;
 
-                // Document reference.
+                // If its just ID of some document from a collection & collection path is provided
                 if (matchesKeyFromCollection) {
                     const docId = data[fieldName];
                     nestedPath = `${matchesKeyFromCollection}/${docId}`;
+                    const nestedResult = await resolveDocument(
+                      store,
+                      nestedPath,
+                      selectionSet
+                    );
+                    docResult[fieldName] = nestedResult;
+                
+                // if field is of Document Reference type, use its path to resolve the document
+                } else if (data[fieldName] != undefined && data[fieldName].constructor!.name! == "DocumentReference") {
+                    nestedPath = `${data[fieldName].path}`;
                     const nestedResult = await resolveDocument(
                         store,
                         nestedPath,
@@ -57,7 +67,7 @@ export async function resolveDocument(
                     );
                     docResult[fieldName] = nestedResult;
 
-                // Nested collection.
+                // Else consider it a nested collection.
                 } else {
                     nestedPath = `${documentPath}/${fieldName}`;
                     const nestedResult = await resolveCollection(

--- a/src/firegraph/Document.ts
+++ b/src/firegraph/Document.ts
@@ -44,13 +44,13 @@ export async function resolveDocument(
             // First, we need to determine which one we are dealing with.
             if (selectionSet && selectionSet.selections) {
                 let nestedPath: string;
-                const { path } = args;
 
                 // If its just raw path of some document
                 if ((typeof data[fieldName]) == "string") { 
                     const docId = data[fieldName];
 
                     // If parent path is provided, consider it
+                    const { path } = args;
                     let documentParentPath:string = path ? path : "";
 
                     nestedPath = `${documentParentPath}${docId}`;

--- a/src/firegraph/Order.ts
+++ b/src/firegraph/Order.ts
@@ -1,0 +1,18 @@
+/**
+ * Applies filters to a Firestore query. Basically chains a series of
+ * calls to `firestore.collection#orderBy`.
+ * @param collectionQuery The query to be made against some collection.
+ * @param order Set of filters formatted as `KEY_COMPARATOR: ASC/DESC` pairs
+ */
+export const setOrders = (
+    collectionQuery: any,
+    orders: any[]
+): firebase.default.firestore.Query => {
+    orders.forEach((filter: any) => {
+        const field: string = filter['key'];
+        const order: any = filter['value'];
+        
+        collectionQuery = collectionQuery.orderBy(field, order);
+    });
+    return collectionQuery;
+}

--- a/src/firegraph/Order.ts
+++ b/src/firegraph/Order.ts
@@ -5,14 +5,14 @@
  * @param order Set of filters formatted as `KEY_COMPARATOR: ASC/DESC` pairs
  */
 export const setOrders = (
-    collectionQuery: any,
-    orders: any[]
+  collectionQuery: any,
+  orders: any[]
 ): firebase.default.firestore.Query => {
-    orders.forEach((filter: any) => {
-        const field: string = filter['key'];
-        const order: any = filter['value'];
-        
-        collectionQuery = collectionQuery.orderBy(field, order);
-    });
-    return collectionQuery;
-}
+  orders.forEach((filter: any) => {
+    const field: string = filter['key'];
+    const order: any = filter['value'];
+
+    collectionQuery = collectionQuery.orderBy(field, order);
+  });
+  return collectionQuery;
+};

--- a/src/firegraph/Where.ts
+++ b/src/firegraph/Where.ts
@@ -47,7 +47,11 @@ export const setQueryFilters = (
         collectionQuery = collectionQuery.where(actualKey, '<=', value);
         break;
       case 'contains':
-        collectionQuery = collectionQuery.where(actualKey, 'array-contains', value);
+        collectionQuery = collectionQuery.where(
+          actualKey,
+          'array-contains',
+          value
+        );
         break;
       default:
         collectionQuery = collectionQuery.where(key, '==', value);

--- a/src/firegraph/Where.ts
+++ b/src/firegraph/Where.ts
@@ -3,16 +3,16 @@
  * @param objectFields Set of key-value pairs in GraphQL AST form.
  */
 export const parseObjectValue = (objectFields: any): any => {
-    return objectFields.map((field: any) => {
-        const { name, value } = field;
-        if (value.kind === 'IntValue') value.value = parseInt(value.value);
+  return objectFields.map((field: any) => {
+    const { name, value } = field;
+    if (value.kind === 'IntValue') value.value = parseInt(value.value);
 
-        return {
-            key: name.value,
-            value: value.value
-        };
-    });
-}
+    return {
+      key: name.value,
+      value: value.value,
+    };
+  });
+};
 
 /**
  * Applies filters to a Firestore query. Basically chains a series of
@@ -21,39 +21,38 @@ export const parseObjectValue = (objectFields: any): any => {
  * @param where Set of filters formatted as `KEY_COMPARATOR: VALUE` pairs
  */
 export const setQueryFilters = (
-    collectionQuery: any,
-    where: any[]
+  collectionQuery: any,
+  where: any[]
 ): firebase.default.firestore.Query => {
-    where.forEach((filter: any) => {
-        const key: string = filter['key'];
-        const value: any = filter['value'];
-        const splitKey: string[] = key.split('_');
-        const whereOp = splitKey[splitKey.length - 1];
-        const actualKey = key.slice(0, -1 * (whereOp.length + 1));
-        switch (whereOp) {
-        case 'eq':
-            collectionQuery = collectionQuery.where(actualKey, '==', value);
-            break;
-        case 'gt':
-            collectionQuery = collectionQuery.where(actualKey, '>', value);
-            break;
-        case 'gte':
-            collectionQuery = collectionQuery.where(actualKey, '>=', value);
-            break;
-        case 'lt':
-            collectionQuery = collectionQuery.where(actualKey, '<', value);
-            break;
-        case 'lte':
-            collectionQuery = collectionQuery.where(actualKey, '<=', value);
-            break;
-        case 'contains':
-            collectionQuery = collectionQuery
-                .where(actualKey, 'array-contains', value);
-            break;
-        default: 
-            collectionQuery = collectionQuery.where(key, '==', value);
-            break;
-        }
-    });
-    return collectionQuery;
-}
+  where.forEach((filter: any) => {
+    const key: string = filter['key'];
+    const value: any = filter['value'];
+    const splitKey: string[] = key.split('_');
+    const whereOp = splitKey[splitKey.length - 1];
+    const actualKey = key.slice(0, -1 * (whereOp.length + 1));
+    switch (whereOp) {
+      case 'eq':
+        collectionQuery = collectionQuery.where(actualKey, '==', value);
+        break;
+      case 'gt':
+        collectionQuery = collectionQuery.where(actualKey, '>', value);
+        break;
+      case 'gte':
+        collectionQuery = collectionQuery.where(actualKey, '>=', value);
+        break;
+      case 'lt':
+        collectionQuery = collectionQuery.where(actualKey, '<', value);
+        break;
+      case 'lte':
+        collectionQuery = collectionQuery.where(actualKey, '<=', value);
+        break;
+      case 'contains':
+        collectionQuery = collectionQuery.where(actualKey, 'array-contains', value);
+        break;
+      default:
+        collectionQuery = collectionQuery.where(key, '==', value);
+        break;
+    }
+  });
+  return collectionQuery;
+};

--- a/src/firegraph/Where.ts
+++ b/src/firegraph/Where.ts
@@ -23,7 +23,7 @@ export const parseObjectValue = (objectFields: any): any => {
 export const setQueryFilters = (
     collectionQuery: any,
     where: any[]
-): firebase.firestore.Query => {
+): firebase.default.firestore.Query => {
     where.forEach((filter: any) => {
         const key: string = filter['key'];
         const value: any = filter['value'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ async function resolve(
                 if (arg.value.kind === 'ObjectValue') {
                     const { fields } = arg.value;
                     parsedArgs[arg.name.value] = parseObjectValue(fields);
+                }else{
+                    parsedArgs[arg.name.value] = arg.value.value;
                 }
             });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import firebase from 'firebase/app';
-import 'firebase/firestore';
 
 // Top-level imports related to Firegraph.
 import { parseObjectValue } from './firegraph/Where';
 import { resolveCollection } from './firegraph/Collection';
 import { FiregraphResult } from './types/Firegraph';
-import CacheManager from './firegraph/CacheManager';
+import { CacheManager } from './firegraph/CacheManager';
 
 /**
  * Runs a GraphQL query against a Google Cloud Firestore instance.
@@ -14,60 +13,60 @@ import CacheManager from './firegraph/CacheManager';
  *        to parse your query, otherwise this will not work.
  */
 async function resolve(
-    firestore: firebase.firestore.Firestore,
-    query: any
+  firestore: firebase.firestore.Firestore,
+  query: any
 ): Promise<FiregraphResult> {
-    const results: FiregraphResult = {};
-    const { definitions } = query;
-    const cacheManager = new CacheManager();
+  const results: FiregraphResult = {};
+  const { definitions } = query;
+  const cacheManager = new CacheManager();
 
-    for (let definition of definitions) {
-        const { selectionSet } = definition;
+  for (let definition of definitions) {
+    const { selectionSet } = definition;
 
-        // Because we know that the root-level values in a query are collection
-        // names, we can define them as collections to be targeted.
-        const targetCollections = selectionSet.selections;
+    // Because we know that the root-level values in a query are collection
+    // names, we can define them as collections to be targeted.
+    const targetCollections = selectionSet.selections;
 
-        // For each collection we have defined in our query, we want to fetch
-        // its name and run the query for the requested values.
-        for (let collection of targetCollections) {
-            const {
-                name: { value: collectionName },
-                selectionSet,
-                arguments: collectionArguments,
-            } = collection;
+    // For each collection we have defined in our query, we want to fetch
+    // its name and run the query for the requested values.
+    for (let collection of targetCollections) {
+      const {
+        name: { value: collectionName },
+        selectionSet,
+        arguments: collectionArguments,
+      } = collection;
 
-            // Parse the GraphQL argument AST into something we can use.
-            const parsedArgs: any = {};
-            collectionArguments.forEach((arg: any) => {
-                if (arg.value.kind === 'ObjectValue') {
-                    const { fields } = arg.value;
-                    parsedArgs[arg.name.value] = parseObjectValue(fields);
-                }else{
-                    parsedArgs[arg.name.value] = arg.value.value;
-                }
-            });
-
-            // Now we begin to recursively fetch values defined in GraphQL
-            // selection sets. We pass our `firestore` instance to ensure
-            // all selections are done from the same database.
-            const result = await resolveCollection(
-                firestore,
-                collectionName,
-                parsedArgs,
-                selectionSet,
-                cacheManager
-            );
-
-            // Push the root query result to our results list.
-            results[result.name] = result.docs;
+      // Parse the GraphQL argument AST into something we can use.
+      const parsedArgs: any = {};
+      collectionArguments.forEach((arg: any) => {
+        if (arg.value.kind === 'ObjectValue') {
+          const { fields } = arg.value;
+          parsedArgs[arg.name.value] = parseObjectValue(fields);
+        } else {
+          parsedArgs[arg.name.value] = arg.value.value;
         }
-    }
+      });
 
-    // All necessary queries have been executed.
-    return results;
+      // Now we begin to recursively fetch values defined in GraphQL
+      // selection sets. We pass our `firestore` instance to ensure
+      // all selections are done from the same database.
+      const result = await resolveCollection(
+        firestore,
+        collectionName,
+        parsedArgs,
+        selectionSet,
+        cacheManager
+      );
+
+      // Push the root query result to our results list.
+      results[result.name] = result.docs;
+    }
+  }
+
+  // All necessary queries have been executed.
+  return results;
 }
 
 export default {
-    resolve
+  resolve,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import 'firebase/firestore';
 import { parseObjectValue } from './firegraph/Where';
 import { resolveCollection } from './firegraph/Collection';
 import { FiregraphResult } from './types/Firegraph';
+import CacheManager from './firegraph/CacheManager';
 
 /**
  * Runs a GraphQL query against a Google Cloud Firestore instance.
@@ -18,6 +19,7 @@ async function resolve(
 ): Promise<FiregraphResult> {
     const results: FiregraphResult = {};
     const { definitions } = query;
+    const cacheManager = new CacheManager();
 
     for (let definition of definitions) {
         const { selectionSet } = definition;
@@ -53,7 +55,8 @@ async function resolve(
                 firestore,
                 collectionName,
                 parsedArgs,
-                selectionSet
+                selectionSet,
+                cacheManager
             );
 
             // Push the root query result to our results list.

--- a/src/types/Firegraph.ts
+++ b/src/types/Firegraph.ts
@@ -1,6 +1,6 @@
 export type FiregraphResult = { [key: string]: any };
 
 export type FiregraphCollectionResult = {
-    name: string;
-    docs: FiregraphResult[];
+  name: string;
+  docs: FiregraphResult[];
 };

--- a/src/types/GraphQL.ts
+++ b/src/types/GraphQL.ts
@@ -1,12 +1,12 @@
 export type GraphQLSelection = {
-    kind: string;
-    alias?: string;
-    arguments?: any[];
-    directives?: any[];
-    selectionSet?: GraphQLSelectionSet;
+  kind: string;
+  alias?: string;
+  arguments?: any[];
+  directives?: any[];
+  selectionSet?: GraphQLSelectionSet;
 };
 
 export type GraphQLSelectionSet = {
-    kind: string;
-    selections?: GraphQLSelection[];
+  kind: string;
+  selections?: GraphQLSelection[];
 };

--- a/test/firebase/index.ts
+++ b/test/firebase/index.ts
@@ -4,12 +4,12 @@ import 'firebase/firestore';
 
 dotenv.config();
 firebase.initializeApp({
-    apiKey: process.env.FIREBASE_API_KEY,
-    authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-    databaseURL: process.env.FIREBASE_DATABASE_URL,
-    projectId: process.env.FIREBASE_PROJECT_ID,
-    storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.FIREBASE_DATABASE_URL,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
 });
 
 export const firestore = firebase.firestore();

--- a/test/firegraph.test.ts
+++ b/test/firegraph.test.ts
@@ -291,7 +291,7 @@ describe('firegraph', () => {
         firestore,
         gql`
           query {
-            posts(orderby: { message: "desc" }) {
+            posts(orderBy: { message: "desc" }) {
               id
               message
             }
@@ -323,7 +323,7 @@ describe('firegraph', () => {
         firestore,
         gql`
           query {
-            posts(orderby: { category: "desc", score: "asc" }) {
+            posts(orderBy: { category: "desc", score: "asc" }) {
               id
               category
               score

--- a/test/firegraph.test.ts
+++ b/test/firegraph.test.ts
@@ -256,4 +256,102 @@ describe('firegraph', () => {
         });
       });
     });
+
+    describe('ORDER', ()=>{
+
+      it('Should order root collection documents', async()=>{
+        const {posts} = await firegraph.resolve(firestore, gql`
+        query{
+          posts(order:{
+            message:"desc"
+          }){
+            id
+            message
+          }
+        }
+        `);
+
+        let messages: string[]=[];
+        let messagesSorted: string[] = [];
+        posts.forEach((post:any) => {
+          expect(post).toHaveProperty("message");
+          messages.push(post.message);
+        });
+
+        // copy & sort the messages
+        messagesSorted = messages.splice(0);
+        messagesSorted = messagesSorted.sort().reverse();
+
+        // test for messages field order
+        if(messages.length > 1){
+          for (let i = 1; i < messages.length; i++) {
+            expect(messages[i]).toEqual(messagesSorted[i]);
+          }
+        }
+
+      })
+
+      it('Should order collection documents by multiple fields', async()=>{
+        const {posts} = await firegraph.resolve(firestore, gql`
+        query{
+          posts(order:{
+            category:"desc",
+            score:"asc"
+          }){
+            id
+            category
+            score
+          }
+        }
+        `);
+
+        let categories: string[]=[];
+        let categoriesSorted: string[]=[];
+        let postScores = new Map();
+
+        posts.forEach((post:any) => {
+          expect(post).toHaveProperty("category");
+          expect(post).toHaveProperty("score");
+
+          const category:string = post.category;
+          const score:number = post.score;
+          
+          categories.push(category);
+
+          if(postScores.has(category)){
+            const nums:number[] = postScores.get(category);
+            nums.push(score);
+            postScores.set(category, nums);
+          }else{
+            const nums:number[] = [];
+            nums.push(score);
+            postScores.set(category, nums);
+          }
+
+        });
+
+        // copy & sort the messages
+        categoriesSorted = categories.splice(0);
+        categoriesSorted = categoriesSorted.sort().reverse();
+
+        // test for messages field order
+        if(categories.length > 1){
+          for (let i = 1; i < categories.length; i++) {
+            expect(categories[i]).toEqual(categoriesSorted[i]);
+          }
+        }
+
+        // Test for score field sort
+        postScores.forEach((value:number[], key:string) => {
+          if(value.length>1){
+            for (let i = 1; i < value.length; i++) {
+              expect(value[i]).toBeGreaterThanOrEqual(value[i-1]);
+            }
+          }
+        });
+
+      })
+
+
+    });
 });

--- a/test/firegraph.test.ts
+++ b/test/firegraph.test.ts
@@ -1,114 +1,127 @@
 import gql from 'graphql-tag';
 import firegraph from '../src';
-import CacheManager from '../src/firegraph/CacheManager';
-import {firestore} from './firebase';
+import { CacheManager } from '../src/firegraph/CacheManager';
+import { firestore } from './firebase';
 
 describe('firegraph', () => {
-    it('should be able to retrieve a collection', async () => {
-        const { posts } = await firegraph.resolve(firestore, gql`
-            query {
-                posts {
-                    id
-                    message
-                }
-            }
-        `);
+  it('should be able to retrieve a collection', async () => {
+    const { posts } = await firegraph.resolve(
+      firestore,
+      gql`
+        query {
+          posts {
+            id
+            message
+          }
+        }
+      `
+    );
 
-        posts.map((post: any) => {
-            expect(post).toHaveProperty('id');
-            expect(post).toHaveProperty('message');
-        });
+    posts.map((post: any) => {
+      expect(post).toHaveProperty('id');
+      expect(post).toHaveProperty('message');
     });
+  });
 
-    it('should be able to retrieve nested collections', async () => {
-        const { posts } = await firegraph.resolve(firestore, gql`
-            query {
-                posts {
-                    id
-                    message
-                    comments {
-                        id
-                        message
-                    }
-                }
+  it('should be able to retrieve nested collections', async () => {
+    const { posts } = await firegraph.resolve(
+      firestore,
+      gql`
+        query {
+          posts {
+            id
+            message
+            comments {
+              id
+              message
             }
-        `);
+          }
+        }
+      `
+    );
 
-        posts.forEach((post: any) => {
-            expect(post).toHaveProperty('comments');
+    posts.forEach((post: any) => {
+      expect(post).toHaveProperty('comments');
 
-            const { comments } = post;
-            comments.forEach((comment: any) => {
-                expect(comment).toHaveProperty('id');
-                expect(comment).toHaveProperty('message');
-            });
-        });
+      const { comments } = post;
+      comments.forEach((comment: any) => {
+        expect(comment).toHaveProperty('id');
+        expect(comment).toHaveProperty('message');
+      });
     });
+  });
 
-    describe('DOCUMENT REFERENCES', ()=>{
-        it('should be able to resolve document reference', async () => {
-        const { posts } = await firegraph.resolve(firestore, gql`
-            query {
-                posts {
-                    id
-                    message
-                    author{
-                        id
-                        fullName
-                        favoriteColor
-                    }
-                }
-            }
-        `);
-
-          posts.forEach((post: any) => {
-              expect(post).toHaveProperty('author');
-
-              const { author } = post;
-              expect(author).toHaveProperty('id');
-              expect(author).toHaveProperty('fullName');
-              expect(author).toHaveProperty('favoriteColor');
-          });
-        });
-
-        it('should be able to resolve raw document reference type and parent path', async () => {
-          const { posts } = await firegraph.resolve(firestore, gql`
-              query {
-                  posts {
-                      id
-                      message
-                      comments{
-                        id
-                        authorId(path:"users/"){   
-                          id
-                          fullName
-                          favoriteColor
-                        }
-                      }
-                  }
+  describe('DOCUMENT REFERENCES', () => {
+    it('should be able to resolve document reference', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts {
+              id
+              message
+              author {
+                id
+                fullName
+                favoriteColor
               }
-          `);
-  
-          posts.forEach((post: any) => {
-              expect(post).toHaveProperty('comments');
+            }
+          }
+        `
+      );
 
-              const {comments} = post;
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('author');
 
-              comments.forEach((comment:any) => {
-
-                expect(comment).toHaveProperty('authorId');
-
-                const {authorId} = comment;
-                expect(authorId).toHaveProperty("id");
-              });
-          });
-        });
+        const { author } = post;
+        expect(author).toHaveProperty('id');
+        expect(author).toHaveProperty('fullName');
+        expect(author).toHaveProperty('favoriteColor');
+      });
     });
 
-    describe('WHERE', () => {
-        it('can filter with key-value equality', async () => {
-            const authorId = 'U7prtqicwDUSKgasXXNv';
-            const { posts } = await firegraph.resolve(firestore, gql`
+    it('should be able to resolve raw document reference type and parent path', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts {
+              id
+              message
+              comments {
+                id
+                authorId(path: "users/") {
+                  id
+                  fullName
+                  favoriteColor
+                }
+              }
+            }
+          }
+        `
+      );
+
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('comments');
+
+        const { comments } = post;
+
+        comments.forEach((comment: any) => {
+          expect(comment).toHaveProperty('authorId');
+
+          const { authorId } = comment;
+          expect(authorId).toHaveProperty('id');
+        });
+      });
+    });
+  });
+
+  describe('WHERE', () => {
+    it('can filter with key-value equality', async () => {
+      const authorId = 'U7prtqicwDUSKgasXXNv';
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
                 query {
                     posts(where: {
                         author: ${authorId},
@@ -120,89 +133,96 @@ describe('firegraph', () => {
                         }
                     }
                 }
-            `);
-    
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('author');
-                expect(post.author).toHaveProperty('id');
-                expect(post.author.id).toEqual('U7prtqicwDUSKgasXXNv');
-            });
-        });
-        it('can filter with `_gt` operator', async () => {
-            const { posts } = await firegraph.resolve(firestore, gql`
-                query {
-                    posts(where: {
-                        score_gt: 6,
-                    }) {
-                        id
-                        score
-                    }
-                }
-            `);
+            `
+      );
 
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('score');
-                expect(post.score).toBeGreaterThan(6);
-            });
-        });
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('author');
+        expect(post.author).toHaveProperty('id');
+        expect(post.author.id).toEqual('U7prtqicwDUSKgasXXNv');
+      });
+    });
+    it('can filter with `_gt` operator', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(where: { score_gt: 6 }) {
+              id
+              score
+            }
+          }
+        `
+      );
 
-        it('can filter with `_gte` operator', async () => {
-            const { posts } = await firegraph.resolve(firestore, gql`
-                query {
-                    posts(where: {
-                        score_gte: 6,
-                    }) {
-                        id
-                        score
-                    }
-                }
-            `);
-    
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('score');
-                expect(post.score).toBeGreaterThanOrEqual(6);
-            });
-        });
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('score');
+        expect(post.score).toBeGreaterThan(6);
+      });
+    });
 
-        it('can filter with `_lt` operator', async () => {
-            const { posts } = await firegraph.resolve(firestore, gql`
-                query {
-                    posts(where: {
-                        score_lt: 14,
-                    }) {
-                        id
-                        score
-                    }
-                }
-            `);
-    
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('score');
-                expect(post.score).toBeLessThan(14);
-            });
-        });
+    it('can filter with `_gte` operator', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(where: { score_gte: 6 }) {
+              id
+              score
+            }
+          }
+        `
+      );
 
-        it('can filter with `_lte` operator', async () => {
-            const { posts } = await firegraph.resolve(firestore, gql`
-                query {
-                    posts(where: {
-                        score_lte: 14,
-                    }) {
-                        id
-                        score
-                    }
-                }
-            `);
-    
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('score');
-                expect(post.score).toBeLessThanOrEqual(14);
-            });
-        });
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('score');
+        expect(post.score).toBeGreaterThanOrEqual(6);
+      });
+    });
 
-        it('can detect array membership with `_contains`', async () => {
-            const someUserId = 'U7prtqicwDUSKgasXXNv';
-            const { posts } = await firegraph.resolve(firestore, gql`
+    it('can filter with `_lt` operator', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(where: { score_lt: 14 }) {
+              id
+              score
+            }
+          }
+        `
+      );
+
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('score');
+        expect(post.score).toBeLessThan(14);
+      });
+    });
+
+    it('can filter with `_lte` operator', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(where: { score_lte: 14 }) {
+              id
+              score
+            }
+          }
+        `
+      );
+
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('score');
+        expect(post.score).toBeLessThanOrEqual(14);
+      });
+    });
+
+    it('can detect array membership with `_contains`', async () => {
+      const someUserId = 'U7prtqicwDUSKgasXXNv';
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
                 query {
                     posts(where: {
                         likes_contains: ${someUserId},
@@ -212,33 +232,39 @@ describe('firegraph', () => {
                         likes
                     }
                 }
-            `);
-    
-            posts.forEach((post: any) => {
-                expect(post).toHaveProperty('likes');
-                expect(post.likes).toContain(someUserId);
-            });
-        });
-    });
+            `
+      );
 
-    describe('LIMIT', () => {
-      it('Should be able to limit root collection query length', async () => {
-        const limit = 1;
-        const { posts } = await firegraph.resolve(firestore, gql`
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('likes');
+        expect(post.likes).toContain(someUserId);
+      });
+    });
+  });
+
+  describe('LIMIT', () => {
+    it('Should be able to limit root collection query length', async () => {
+      const limit = 1;
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
             query {
                 posts(limit:${limit}) {
                     id
                 }
             }
-        `);
-  
-        expect(posts.length).toBeLessThanOrEqual(limit);
-      });
-  
-      it('Should be able to limit nested collection query length', async () => {
-        const root_limit = 1;
-        const sub_limit = 1;
-        const { posts } = await firegraph.resolve(firestore, gql`
+        `
+      );
+
+      expect(posts.length).toBeLessThanOrEqual(limit);
+    });
+
+    it('Should be able to limit nested collection query length', async () => {
+      const root_limit = 1;
+      const sub_limit = 1;
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
             query {
                 posts(limit:${root_limit}){
                     id
@@ -247,152 +273,148 @@ describe('firegraph', () => {
                     }
                 }
             }
-        `);
-  
-        expect(posts.length).toBeLessThanOrEqual(root_limit);
+        `
+      );
 
-        posts.forEach((post: any) => {
-          expect(post).toHaveProperty('comments');
-          expect(post.comments.length).toBeLessThanOrEqual(sub_limit);
-        });
+      expect(posts.length).toBeLessThanOrEqual(root_limit);
+
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('comments');
+        expect(post.comments.length).toBeLessThanOrEqual(sub_limit);
       });
     });
+  });
 
-    describe('ORDER', ()=>{
-
-      it('Should order root collection documents', async()=>{
-        const {posts} = await firegraph.resolve(firestore, gql`
-        query{
-          posts(orderby:{
-            message:"desc"
-          }){
-            id
-            message
-          }
-        }
-        `);
-
-        let messages: string[]=[];
-        let messagesSorted: string[] = [];
-        posts.forEach((post:any) => {
-          expect(post).toHaveProperty("message");
-          messages.push(post.message);
-        });
-
-        // copy & sort the messages
-        messagesSorted = messages.splice(0);
-        messagesSorted = messagesSorted.sort().reverse();
-
-        // test for messages field order
-        if(messages.length > 1){
-          for (let i = 1; i < messages.length; i++) {
-            expect(messages[i]).toEqual(messagesSorted[i]);
-          }
-        }
-
-      })
-
-      it('Should order collection documents by multiple fields', async()=>{
-        const {posts} = await firegraph.resolve(firestore, gql`
-        query{
-          posts(orderby:{
-            category:"desc",
-            score:"asc"
-          }){
-            id
-            category
-            score
-          }
-        }
-        `);
-
-        let categories: string[]=[];
-        let categoriesSorted: string[]=[];
-        let postScores = new Map();
-
-        posts.forEach((post:any) => {
-          expect(post).toHaveProperty("category");
-          expect(post).toHaveProperty("score");
-
-          const category:string = post.category;
-          const score:number = post.score;
-          
-          categories.push(category);
-
-          if(postScores.has(category)){
-            const nums:number[] = postScores.get(category);
-            nums.push(score);
-            postScores.set(category, nums);
-          }else{
-            const nums:number[] = [];
-            nums.push(score);
-            postScores.set(category, nums);
-          }
-
-        });
-
-        // copy & sort the messages
-        categoriesSorted = categories.splice(0);
-        categoriesSorted = categoriesSorted.sort().reverse();
-
-        // test for messages field order
-        if(categories.length > 1){
-          for (let i = 1; i < categories.length; i++) {
-            expect(categories[i]).toEqual(categoriesSorted[i]);
-          }
-        }
-
-        // Test for score field sort
-        postScores.forEach((value:number[], key:string) => {
-          if(value.length>1){
-            for (let i = 1; i < value.length; i++) {
-              expect(value[i]).toBeGreaterThanOrEqual(value[i-1]);
+  describe('ORDER', () => {
+    it('Should order root collection documents', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(orderby: { message: "desc" }) {
+              id
+              message
             }
           }
-        });
+        `
+      );
 
-      })
+      let messages: string[] = [];
+      let messagesSorted: string[] = [];
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('message');
+        messages.push(post.message);
+      });
 
+      // copy & sort the messages
+      messagesSorted = messages.splice(0);
+      messagesSorted = messagesSorted.sort().reverse();
 
+      // test for messages field order
+      if (messages.length > 1) {
+        for (let i = 1; i < messages.length; i++) {
+          expect(messages[i]).toEqual(messagesSorted[i]);
+        }
+      }
     });
 
-    it('Should be able to use cached documents', async()=>{
+    it('Should order collection documents by multiple fields', async () => {
+      const { posts } = await firegraph.resolve(
+        firestore,
+        gql`
+          query {
+            posts(orderby: { category: "desc", score: "asc" }) {
+              id
+              category
+              score
+            }
+          }
+        `
+      );
 
-      let hits = 0;
-      const listener = {
-        onCacheHit:(path:string)=>{
-          hits++;
-        },
-        onCacheMiss:(path:string)=>{},
-        onCacheSaved:(path:string)=>{},
-        onCacheRequested:(path:string)=>{}
-      };
+      let categories: string[] = [];
+      let categoriesSorted: string[] = [];
+      let postScores = new Map();
 
-      CacheManager.addListener(listener);
-      
+      posts.forEach((post: any) => {
+        expect(post).toHaveProperty('category');
+        expect(post).toHaveProperty('score');
 
-      // Only author documents will overlap with users docs... so total 2 cache hits
-      const {posts} = await firegraph.resolve(firestore, gql`
-        query{
-          posts(limit:2){
-            id,
-            message,
-            author{
-              id,
+        const category: string = post.category;
+        const score: number = post.score;
+
+        categories.push(category);
+
+        if (postScores.has(category)) {
+          const nums: number[] = postScores.get(category);
+          nums.push(score);
+          postScores.set(category, nums);
+        } else {
+          const nums: number[] = [];
+          nums.push(score);
+          postScores.set(category, nums);
+        }
+      });
+
+      // copy & sort the messages
+      categoriesSorted = categories.splice(0);
+      categoriesSorted = categoriesSorted.sort().reverse();
+
+      // test for messages field order
+      if (categories.length > 1) {
+        for (let i = 1; i < categories.length; i++) {
+          expect(categories[i]).toEqual(categoriesSorted[i]);
+        }
+      }
+
+      // Test for score field sort
+      postScores.forEach((value: number[], key: string) => {
+        if (value.length > 1) {
+          for (let i = 1; i < value.length; i++) {
+            expect(value[i]).toBeGreaterThanOrEqual(value[i - 1]);
+          }
+        }
+      });
+    });
+  });
+
+  it('Should be able to use cached documents', async () => {
+    let hits = 0;
+    const listener = {
+      onCacheHit: (path: string) => {
+        hits++;
+      },
+      onCacheMiss: (path: string) => {},
+      onCacheSaved: (path: string) => {},
+      onCacheRequested: (path: string) => {},
+    };
+
+    CacheManager.addListener(listener);
+
+    // Only author documents will overlap with users docs... so total 2 cache hits
+    const { posts } = await firegraph.resolve(
+      firestore,
+      gql`
+        query {
+          posts(limit: 2) {
+            id
+            message
+            author {
+              id
               fullName
             }
           }
-          users{
+          users {
             id
             fullName
           }
         }
-      `);
+      `
+    );
 
-      // Mathematically number of author document read overlaps
-      // should be equal to number of posts
-      expect(hits).toEqual(posts.length);
-      CacheManager.removeListener(listener);
-
-    });
+    // Mathematically number of author document read overlaps
+    // should be equal to number of posts
+    expect(hits).toEqual(posts.length);
+    CacheManager.removeListener(listener);
+  });
 });

--- a/test/firegraph.test.ts
+++ b/test/firegraph.test.ts
@@ -262,7 +262,7 @@ describe('firegraph', () => {
       it('Should order root collection documents', async()=>{
         const {posts} = await firegraph.resolve(firestore, gql`
         query{
-          posts(order:{
+          posts(orderby:{
             message:"desc"
           }){
             id
@@ -294,7 +294,7 @@ describe('firegraph', () => {
       it('Should order collection documents by multiple fields', async()=>{
         const {posts} = await firegraph.resolve(firestore, gql`
         query{
-          posts(order:{
+          posts(orderby:{
             category:"desc",
             score:"asc"
           }){

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "files": [
-    "src/index.ts"
+  "include": [
+    "src/"
   ],
   "compilerOptions": {
     /* Basic Options */


### PR DESCRIPTION
Firstly updated dependencies and performed some fixes for package builds.

Then Added extended support for document references by also considering string fields as path, as well as having argument of `path` for providing a parent path to the document path stored in string field